### PR TITLE
Update to v0.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.1
+        uses: yetanalytics/actions/setup-env@v0.0.2
       
       - name: Test deployment
-        uses: yetanalytics/actions/deploy-clojars@clojars-publish-fix
+        uses: yetanalytics/actions/deploy-clojars@v0.0.2
         with:
           artifact-id: 'actions'
           version: 'LATEST'
@@ -32,4 +32,4 @@ jobs:
           clojars-deploy-token: 'bar'
 
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.1
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.2

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Clojure env
-        uses: yetanalytics/actions/setup-env@v0.0.1
+        uses: yetanalytics/actions/setup-env@v0.0.2
 
       - name: Get current date
         id: date


### PR DESCRIPTION
I managed to get all refs in v0.0.2 in referencing v0.0.2 itself by pushing the tag off of the side branch first, _then_ pushing the updated code itself.