### PR TITLE
Update versions and remove deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test3
+        uses: yetanalytics/actions/setup-env@v0.0.4-test4
       
       - name: Test deployment
-        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test3
+        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test4
         with:
           artifact-id: 'actions'
           version: 'LATEST'
@@ -32,4 +32,4 @@ jobs:
           clojars-deploy-token: 'bar'
 
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test3
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get an env
         uses: yetanalytics/actions/setup-env@v0.0.4-test2
@@ -32,4 +32,4 @@ jobs:
           clojars-deploy-token: 'bar'
 
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.2
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test5
+        uses: yetanalytics/actions/setup-env@v0.0.4
       
       - name: Test deployment
-        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test5
+        uses: yetanalytics/actions/deploy-clojars@v0.0.4
         with:
           artifact-id: 'actions'
           version: 'LATEST'
@@ -32,4 +32,4 @@ jobs:
           clojars-deploy-token: 'bar'
 
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test5
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test4
+        uses: yetanalytics/actions/setup-env@v0.0.4-test5
       
       - name: Test deployment
-        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test4
+        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test5
         with:
           artifact-id: 'actions'
           version: 'LATEST'
@@ -32,4 +32,4 @@ jobs:
           clojars-deploy-token: 'bar'
 
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test4
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test2
+        uses: yetanalytics/actions/setup-env@v0.0.4-test3
       
       - name: Test deployment
-        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test2
+        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test3
         with:
           artifact-id: 'actions'
           version: 'LATEST'
@@ -32,4 +32,4 @@ jobs:
           clojars-deploy-token: 'bar'
 
   nvd_scan:
-    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test2
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.4-test3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get an env
-        uses: yetanalytics/actions/setup-env@v0.0.2
+        uses: yetanalytics/actions/setup-env@v0.0.4-test2
       
       - name: Test deployment
-        uses: yetanalytics/actions/deploy-clojars@v0.0.2
+        uses: yetanalytics/actions/deploy-clojars@v0.0.4-test2
         with:
           artifact-id: 'actions'
           version: 'LATEST'

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -25,10 +25,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout calling project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Clojure env
-        uses: yetanalytics/actions/setup-env@v0.0.2
+        uses: yetanalytics/actions/setup-env@v0.0.4-test2
 
       - name: Get current date
         id: date
@@ -62,7 +62,7 @@ jobs:
           :config-filename '"${{ inputs.nvd-config-filename }}"'
 
       - name: Produce Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }} # Always produce an artifact
         with:
           name: ${{ github.sha }}-nvd-report

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Clojure env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test3
+        uses: yetanalytics/actions/setup-env@v0.0.4-test4
 
       - name: Get current date
         id: date

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -38,7 +38,7 @@ jobs:
           echo "d=$(date +'%d')" >> $GITHUB_OUTPUT
 
       - name: Cache any deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Clojure env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test4
+        uses: yetanalytics/actions/setup-env@v0.0.4-test5
 
       - name: Get current date
         id: date

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -12,7 +12,7 @@ on:
         required: false
         description: nvd-clojure version
         type: string
-        default: '2.5.0'
+        default: '2.9.0'
       nvd-config-filename:
         required: false
         description: nvd-clojure configuration file

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Clojure env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test5
+        uses: yetanalytics/actions/setup-env@v0.0.4
 
       - name: Get current date
         id: date

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Clojure env
-        uses: yetanalytics/actions/setup-env@v0.0.4-test2
+        uses: yetanalytics/actions/setup-env@v0.0.4-test3
 
       - name: Get current date
         id: date

--- a/.github/workflows/nvd-scan.yml
+++ b/.github/workflows/nvd-scan.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Get current date
         id: date
         run: |
-          echo "::set-output name=y::$(date +'%Y')"
-          echo "::set-output name=m::$(date +'%m')"
-          echo "::set-output name=d::$(date +'%d')"
+          echo "y=$(date +'%Y')" >> $GITHUB_OUTPUT
+          echo "m=$(date +'%m')" >> $GITHUB_OUTPUT
+          echo "d=$(date +'%d')" >> $GITHUB_OUTPUT
 
       - name: Cache any deps
         uses: actions/cache@v2

--- a/deploy-clojars/action.yml
+++ b/deploy-clojars/action.yml
@@ -77,7 +77,7 @@ runs:
 
     # This is a debug step that exists for sanity checking
     - name: Publish artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifact-id }}-artifact-${{ inputs.version }}
         path: target/${{ inputs.artifact-id }}-${{ inputs.version }}.jar

--- a/deploy-clojars/action.yml
+++ b/deploy-clojars/action.yml
@@ -56,7 +56,7 @@ runs:
         echo "aliases='{:aliases
         {:build
         {:replace-deps {io.github.seancorfield/build-clj
-        {:git/tag \"v0.6.3\" :git/sha \"9b8e09b\" }}
+        {:git/tag \"v0.8.3\" :git/sha \"7ac1f8d\" }}
         :ns-default org.corfield.build }}}'"
         >> $GITHUB_OUTPUT
 

--- a/deploy-clojars/action.yml
+++ b/deploy-clojars/action.yml
@@ -53,11 +53,12 @@ runs:
       id: 'build-aliases'
       shell: bash
       run: >-
-        echo "::set-output name=aliases::'{:aliases
+        echo "aliases='{:aliases
         {:build
         {:replace-deps {io.github.seancorfield/build-clj
         {:git/tag \"v0.6.3\" :git/sha \"9b8e09b\" }}
         :ns-default org.corfield.build }}}'"
+        >> $GITHUB_OUTPUT
 
     - name: Build JAR file
       shell: bash

--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -21,7 +21,7 @@ inputs:
   clojure-version:
     description: Version of Clojure CLI to install
     required: true
-    default: '1.10.3.1040'
+    default: '1.11.1'
 
 runs:
   using: "composite"

--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -27,17 +27,17 @@ runs:
   using: "composite"
   steps:
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: ${{ inputs.java-distribution }}
         java-version: ${{ inputs.java-version }}
 
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Setup Clojure
-      uses: DeLaGuardo/setup-clojure@3.5
+      uses: DeLaGuardo/setup-clojure@9.5
       with:
         cli: ${{ inputs.clojure-version }}

--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -21,7 +21,7 @@ inputs:
   clojure-version:
     description: Version of Clojure CLI to install
     required: true
-    default: '1.11.1'
+    default: '1.11.1.1165'
 
 runs:
   using: "composite"

--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -16,7 +16,7 @@ inputs:
   node-version:
     description: Version of node to install
     required: true
-    default: '14'
+    default: '16'
 
   clojure-version:
     description: Version of Clojure CLI to install


### PR DESCRIPTION
- Update dependent actions and libs to their latest versions
  - `actions/checkout`: version 2 to 3
  - `actions/setup-java`: version 2 to 3
  - `actions/setup-node`: version 2 to 3
  - `actions/cache`: version 2 to 3
  - `actions/upload-artifact`: version 2 to 3
  - `DeLaGuardo/setup-clojure`: version 2.5 to 9.5
  - `io.github.seancorfield/build-clj`: version 0.6.3 to 0.8.3
- Update default versions:
  - Node version for `setup-env` from 14 to 16
  - Clojure version for `setup-env` to 1.11.1.1165
  - NVD-Clojure version for `nvd-scan` to 2.9.0
- Remove deprecated `set-output` command